### PR TITLE
Add AWS Bedrock builders (Agent, Knowledge Base, Data Source, Guardrail)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Notes:
 
 ## Supported AWS Services
 
-FsCDK provides F# builders for 30+ AWS services across all major categories:
+FsCDK provides F# builders for 35+ AWS services across all major categories:
 
 | Service | What it does |
 |---------|--------------|
@@ -92,6 +92,7 @@ FsCDK provides F# builders for 30+ AWS services across all major categories:
 | **App Runner** | Fully managed container service for web apps and APIs |
 | **AppSync** | Builds managed GraphQL APIs with real-time data synchronization |
 | **Bastion Host** | Secure SSH access to instances in private subnets - [📚 Docs with learning resources](https://totallymoney.github.io/FsCDK/bastion-host.html) |
+| **Bedrock** | AI/ML foundation models with Agents, Knowledge Bases, Data Sources, and Guardrails - [📚 Docs with learning resources](https://totallymoney.github.io/FsCDK/bedrock.html) |
 | **Certificate Manager** | Manages SSL/TLS certificates for secure connections - [📚 Docs with learning resources](https://totallymoney.github.io/FsCDK/certificate-manager.html) |
 | **CloudFront** | Content delivery network (CDN) for fast global content distribution |
 | **CloudHSM** | Hardware security modules for cryptographic key storage |

--- a/docs/bedrock.fsx
+++ b/docs/bedrock.fsx
@@ -1,0 +1,301 @@
+(**
+---
+title: Amazon Bedrock
+category: Resources
+categoryindex: 22
+---
+
+# Amazon Bedrock: Generative AI with FsCDK
+
+Amazon Bedrock is a fully managed service that makes foundation models (FMs) from leading AI companies available through a unified API. FsCDK provides type-safe builders for Bedrock Agents, Knowledge Bases, Data Sources, and Guardrails.
+
+## What is Amazon Bedrock?
+
+Amazon Bedrock lets you build and scale generative AI applications using foundation models from Anthropic (Claude), Amazon (Titan), Meta (Llama), and others. Key components include:
+
+- **Agents** - Autonomous AI assistants that can plan and execute tasks
+- **Knowledge Bases** - RAG (Retrieval-Augmented Generation) with your data
+- **Data Sources** - Connect S3, web crawlers, and other data to Knowledge Bases
+- **Guardrails** - Content filtering and safety controls for AI responses
+
+## Quick Start
+*)
+
+#r "../src/bin/Release/net8.0/publish/Amazon.JSII.Runtime.dll"
+#r "../src/bin/Release/net8.0/publish/Constructs.dll"
+#r "../src/bin/Release/net8.0/publish/Amazon.CDK.Lib.dll"
+#r "../src/bin/Release/net8.0/publish/System.Text.Json.dll"
+#r "../src/bin/Release/net8.0/publish/FsCDK.dll"
+
+open Amazon.CDK
+open Amazon.CDK.AwsBedrock
+open FsCDK
+
+(*** hide ***)
+module Config =
+    let get () =
+        {| Account = System.Environment.GetEnvironmentVariable("CDK_DEFAULT_ACCOUNT")
+           Region = System.Environment.GetEnvironmentVariable("CDK_DEFAULT_REGION") |}
+
+let config = Config.get ()
+
+stack "BasicBedrockStack" {
+    description "Basic Bedrock Agent"
+
+    let myAgent =
+        bedrockAgent "MyAssistant" {
+            foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+            instruction "You are a helpful assistant that answers questions about our products."
+            description "Customer support assistant"
+            agentResourceRoleArn "arn:aws:iam::123456789012:role/BedrockAgentRole"
+        }
+
+    ()
+}
+
+(**
+## Use Cases
+
+### AI Agent with Custom Instructions
+*)
+
+stack "AgentStack" {
+    description "Bedrock Agent with full configuration"
+
+    let supportAgent =
+        bedrockAgent "CustomerSupportAgent" {
+            foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+
+            instruction
+                "You are a customer support agent. Help users with order tracking, returns, and product questions."
+
+            description "Handles customer inquiries"
+            agentResourceRoleArn "arn:aws:iam::123456789012:role/BedrockAgentRole"
+            idleSessionTtlInSeconds 1800
+            autoPrepare true
+            tags [ "Team", "AI"; "Environment", "Production" ]
+        }
+
+    ()
+}
+
+(**
+### Knowledge Base with RAG
+*)
+
+stack "KnowledgeBaseStack" {
+    description "Bedrock Knowledge Base for document retrieval"
+
+    let kbConfig =
+        CfnKnowledgeBase.KnowledgeBaseConfigurationProperty(
+            Type = "VECTOR",
+            VectorKnowledgeBaseConfiguration =
+                CfnKnowledgeBase.VectorKnowledgeBaseConfigurationProperty(
+                    EmbeddingModelArn = "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v2:0"
+                )
+        )
+
+    let storageConfig =
+        CfnKnowledgeBase.StorageConfigurationProperty(
+            Type = "OPENSEARCH_SERVERLESS",
+            OpensearchServerlessConfiguration =
+                CfnKnowledgeBase.OpenSearchServerlessConfigurationProperty(
+                    CollectionArn = "arn:aws:aoss:us-east-1:123456789012:collection/my-collection",
+                    FieldMapping =
+                        CfnKnowledgeBase.OpenSearchServerlessFieldMappingProperty(
+                            MetadataField = "metadata",
+                            TextField = "text",
+                            VectorField = "vector"
+                        ),
+                    VectorIndexName = "my-index"
+                )
+        )
+
+    let productKB =
+        bedrockKnowledgeBase "ProductDocsKB" {
+            description "Knowledge base for product documentation"
+            roleArn "arn:aws:iam::123456789012:role/BedrockKBRole"
+            knowledgeBaseConfiguration kbConfig
+            storageConfiguration storageConfig
+            tags [ "Team", "AI" ]
+        }
+
+    ()
+}
+
+(**
+### Data Source from S3
+*)
+
+stack "DataSourceStack" {
+    description "Bedrock Data Source connected to S3"
+
+    let s3Config =
+        CfnDataSource.DataSourceConfigurationProperty(
+            Type = "S3",
+            S3Configuration = CfnDataSource.S3DataSourceConfigurationProperty(BucketArn = "arn:aws:s3:::my-docs-bucket")
+        )
+
+    let docsSource =
+        bedrockDataSource "ProductDocsSource" {
+            knowledgeBaseId "KBXXXXXXXX"
+            description "S3 bucket containing product documentation"
+            dataSourceConfiguration s3Config
+            dataDeletionPolicy "RETAIN"
+        }
+
+    ()
+}
+
+(**
+### Content Safety Guardrail
+*)
+
+stack "GuardrailStack" {
+    description "Bedrock Guardrail for content safety"
+
+    let safetyGuardrail =
+        bedrockGuardrail "ContentSafety" {
+            description "Filters harmful and inappropriate content"
+            blockedInputMessaging "Your input contains content that is not allowed."
+            blockedOutputsMessaging "The response was filtered for safety."
+
+            contentPolicyConfig (
+                CfnGuardrail.ContentPolicyConfigProperty(
+                    FiltersConfig =
+                        [| CfnGuardrail.ContentFilterConfigProperty(
+                               Type = "SEXUAL",
+                               InputStrength = "HIGH",
+                               OutputStrength = "HIGH"
+                           )
+                           CfnGuardrail.ContentFilterConfigProperty(
+                               Type = "VIOLENCE",
+                               InputStrength = "HIGH",
+                               OutputStrength = "HIGH"
+                           )
+                           CfnGuardrail.ContentFilterConfigProperty(
+                               Type = "HATE",
+                               InputStrength = "HIGH",
+                               OutputStrength = "HIGH"
+                           ) |]
+                )
+            )
+
+            tags [ "Environment", "Production" ]
+        }
+
+    ()
+}
+
+(**
+## Complete Production Example
+*)
+
+stack "ProductionBedrockStack" {
+    env (
+        environment {
+            account config.Account
+            region config.Region
+        }
+    )
+
+    description "Production Bedrock AI platform"
+    tags [ "Environment", "Production"; "ManagedBy", "FsCDK" ]
+
+    // Content safety guardrail
+    let guardrail =
+        bedrockGuardrail "ProductionSafety" {
+            description "Production content safety filters"
+            blockedInputMessaging "This input is not permitted."
+            blockedOutputsMessaging "This response has been filtered."
+
+            contentPolicyConfig (
+                CfnGuardrail.ContentPolicyConfigProperty(
+                    FiltersConfig =
+                        [| CfnGuardrail.ContentFilterConfigProperty(
+                               Type = "SEXUAL",
+                               InputStrength = "HIGH",
+                               OutputStrength = "HIGH"
+                           )
+                           CfnGuardrail.ContentFilterConfigProperty(
+                               Type = "VIOLENCE",
+                               InputStrength = "HIGH",
+                               OutputStrength = "HIGH"
+                           ) |]
+                )
+            )
+
+            topicPolicyConfig (
+                CfnGuardrail.TopicPolicyConfigProperty(
+                    TopicsConfig =
+                        [| CfnGuardrail.TopicConfigProperty(
+                               Name = "Financial Advice",
+                               Definition = "Providing specific investment or financial planning advice",
+                               Type = "DENY"
+                           ) |]
+                )
+            )
+
+            kmsKeyArn "arn:aws:kms:us-east-1:123456789012:key/my-key"
+            tags [ "Environment", "Production" ]
+        }
+
+    // AI Agent
+    let agent =
+        bedrockAgent "ProductionAgent" {
+            foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+            instruction "You are a helpful product assistant. Answer questions accurately based on the knowledge base."
+            description "Production customer-facing AI agent"
+            agentResourceRoleArn "arn:aws:iam::123456789012:role/BedrockAgentRole"
+            idleSessionTtlInSeconds 3600
+            autoPrepare true
+            tags [ "Environment", "Production" ]
+        }
+
+    ()
+}
+
+(**
+## Best Practices
+
+### Security
+- Use **KMS encryption** for guardrails and agents handling sensitive data
+- Apply **least-privilege IAM roles** for agent resource roles
+- Enable **guardrails** on all customer-facing agents to prevent harmful content
+- Use **topic policies** to prevent the agent from discussing prohibited subjects
+
+### Cost
+- Choose the right **foundation model** for your use case (smaller models for simpler tasks)
+- Set appropriate **idle session TTL** to avoid unnecessary session costs
+- Use **data deletion policies** (RETAIN vs DELETE) based on compliance needs
+
+### Reliability
+- Set **autoPrepare** to true (default) so agents are ready after deployment
+- Use **content filters** at HIGH strength for production workloads
+- Test guardrails thoroughly before deploying to production
+
+### Operational Excellence
+- Tag all Bedrock resources for cost allocation and tracking
+- Use separate agents for different use cases rather than one monolithic agent
+- Version your knowledge base data sources for reproducibility
+
+## Default Settings
+
+| Setting | Default | Rationale |
+|---------|---------|-----------|
+| `autoPrepare` | `true` | Agent is immediately available after deployment |
+
+## Escape Hatch
+
+Access the underlying CDK resources via the mutable `Agent`, `KnowledgeBase`, `DataSource`, or `Guardrail` properties on the spec records after stack synthesis for advanced scenarios not covered by these builders.
+
+## Learning Resources
+
+- [Amazon Bedrock Developer Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/) - Official AWS documentation
+- [Bedrock Agents](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html) - Building autonomous AI agents
+- [Knowledge Bases for Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html) - RAG with your data
+- [Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) - Content safety controls
+*)
+
+(*** hide ***)
+()

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -243,6 +243,7 @@ table th {
 | ![App Runner](img/icons/Arch_AWS-App-Runner_48.png) | **App Runner** | Fully managed container service for web apps and APIs |
 | ![AppSync](img/icons/Arch_AWS-AppSync_48.png) | **AppSync** | Builds managed GraphQL APIs with real-time data synchronization |
 | [![Bastion Host](img/icons/Res_Amazon-EC2_Instance_48.png)](bastion-host.html) | [**Bastion Host**](bastion-host.html) | Secure SSH access to instances in private subnets 📚 *with curated learning resources* |
+| | [**Bedrock**](bedrock.html) | Foundation models for generative AI applications (Agents, Knowledge Bases, Guardrails) |
 | [![Certificate Manager](img/icons/Arch_AWS-Certificate-Manager_48.png)](certificate-manager.html) | [**Certificate Manager**](certificate-manager.html) | Manages SSL/TLS certificates for secure connections 📚 *with curated learning resources* |
 | ![CloudFront](img/icons/Arch_Amazon-CloudFront_48.png) | **CloudFront** | Content delivery network (CDN) for fast global content distribution |
 | ![CloudHSM](img/icons/Arch_AWS-CloudHSM_48.png) | **CloudHSM** | Hardware security modules for cryptographic key storage |

--- a/src/Bedrock.fs
+++ b/src/Bedrock.fs
@@ -1,0 +1,972 @@
+namespace FsCDK
+
+open Amazon.CDK
+open Amazon.CDK.AwsBedrock
+open System.Collections.Generic
+
+// ============================================================================
+// AWS Bedrock Configuration DSL
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Bedrock Agent
+// ----------------------------------------------------------------------------
+
+/// <summary>Configuration for a Bedrock Agent resource.</summary>
+type BedrockAgentConfig =
+    { AgentName: string
+      ConstructId: string option
+      FoundationModel: string option
+      Instruction: string option
+      Description: string option
+      AgentResourceRoleArn: string option
+      IdleSessionTtlInSeconds: int option
+      AutoPrepare: bool option
+      CustomerEncryptionKeyArn: string option
+      SkipResourceInUseCheckOnDelete: bool option
+      Tags: (string * string) list }
+
+/// <summary>Spec for a Bedrock Agent, holding the resolved props and mutable resource reference.</summary>
+type BedrockAgentSpec =
+    { AgentName: string
+      ConstructId: string
+      Props: CfnAgentProps
+      mutable Agent: CfnAgent option }
+
+type BedrockAgentBuilder(name: string) =
+    member _.Yield(_: unit) : BedrockAgentConfig =
+        { AgentName = name
+          ConstructId = None
+          FoundationModel = None
+          Instruction = None
+          Description = None
+          AgentResourceRoleArn = None
+          IdleSessionTtlInSeconds = None
+          AutoPrepare = Some true
+          CustomerEncryptionKeyArn = None
+          SkipResourceInUseCheckOnDelete = None
+          Tags = [] }
+
+    member _.Zero() : BedrockAgentConfig =
+        { AgentName = name
+          ConstructId = None
+          FoundationModel = None
+          Instruction = None
+          Description = None
+          AgentResourceRoleArn = None
+          IdleSessionTtlInSeconds = None
+          AutoPrepare = Some true
+          CustomerEncryptionKeyArn = None
+          SkipResourceInUseCheckOnDelete = None
+          Tags = [] }
+
+    member inline _.Delay([<InlineIfLambda>] f: unit -> BedrockAgentConfig) : BedrockAgentConfig = f ()
+
+    member _.Combine(state1: BedrockAgentConfig, state2: BedrockAgentConfig) : BedrockAgentConfig =
+        { AgentName = state2.AgentName
+          ConstructId = state2.ConstructId |> Option.orElse state1.ConstructId
+          FoundationModel = state2.FoundationModel |> Option.orElse state1.FoundationModel
+          Instruction = state2.Instruction |> Option.orElse state1.Instruction
+          Description = state2.Description |> Option.orElse state1.Description
+          AgentResourceRoleArn = state2.AgentResourceRoleArn |> Option.orElse state1.AgentResourceRoleArn
+          IdleSessionTtlInSeconds = state2.IdleSessionTtlInSeconds |> Option.orElse state1.IdleSessionTtlInSeconds
+          AutoPrepare = state2.AutoPrepare |> Option.orElse state1.AutoPrepare
+          CustomerEncryptionKeyArn = state2.CustomerEncryptionKeyArn |> Option.orElse state1.CustomerEncryptionKeyArn
+          SkipResourceInUseCheckOnDelete =
+            state2.SkipResourceInUseCheckOnDelete
+            |> Option.orElse state1.SkipResourceInUseCheckOnDelete
+          Tags =
+            if state2.Tags.IsEmpty then
+                state1.Tags
+            else
+                state2.Tags @ state1.Tags }
+
+    member inline x.For
+        (
+            config: BedrockAgentConfig,
+            [<InlineIfLambda>] f: unit -> BedrockAgentConfig
+        ) : BedrockAgentConfig =
+        let newConfig = f ()
+        x.Combine(config, newConfig)
+
+    member _.Run(config: BedrockAgentConfig) : BedrockAgentSpec =
+        let constructId = config.ConstructId |> Option.defaultValue config.AgentName
+
+        let props = CfnAgentProps()
+
+        props.AgentName <- config.AgentName
+
+        props.FoundationModel <-
+            match config.FoundationModel with
+            | Some m -> m
+            | None -> failwith "Bedrock Agent foundation model is required"
+
+        config.Instruction |> Option.iter (fun i -> props.Instruction <- i)
+        config.Description |> Option.iter (fun d -> props.Description <- d)
+
+        config.AgentResourceRoleArn
+        |> Option.iter (fun r -> props.AgentResourceRoleArn <- r)
+
+        config.IdleSessionTtlInSeconds
+        |> Option.iter (fun t -> props.IdleSessionTtlInSeconds <- t)
+
+        config.AutoPrepare |> Option.iter (fun a -> props.AutoPrepare <- a)
+
+        config.CustomerEncryptionKeyArn
+        |> Option.iter (fun k -> props.CustomerEncryptionKeyArn <- k)
+
+        config.SkipResourceInUseCheckOnDelete
+        |> Option.iter (fun s -> props.SkipResourceInUseCheckOnDelete <- s)
+
+        if not (List.isEmpty config.Tags) then
+            let tagDict = Dictionary<string, string>()
+
+            for key, value in config.Tags do
+                tagDict[key] <- value
+
+            props.Tags <- tagDict
+
+        { AgentName = config.AgentName
+          ConstructId = constructId
+          Props = props
+          Agent = None }
+
+    /// <summary>Sets the construct ID for the Bedrock agent.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="id">The construct ID.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     constructId "MyAgentConstruct"
+    /// }
+    /// </code>
+    [<CustomOperation("constructId")>]
+    member _.ConstructId(config: BedrockAgentConfig, id: string) = { config with ConstructId = Some id }
+
+    /// <summary>Sets the foundation model for the agent (e.g., "anthropic.claude-3-sonnet-20240229-v1:0").</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="model">The foundation model identifier string.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+    /// }
+    /// </code>
+    [<CustomOperation("foundationModel")>]
+    member _.FoundationModel(config: BedrockAgentConfig, model: string) =
+        { config with
+            FoundationModel = Some model }
+
+    /// <summary>Sets the foundation model using a FoundationModelIdentifier.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="model">The foundation model identifier.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     foundationModelId FoundationModelIdentifier.ANTHROPIC_CLAUDE_3_SONNET_20240229_V1_0
+    /// }
+    /// </code>
+    [<CustomOperation("foundationModelId")>]
+    member _.FoundationModelId(config: BedrockAgentConfig, model: FoundationModelIdentifier) =
+        { config with
+            FoundationModel = Some model.ModelId }
+
+    /// <summary>Sets the instruction/system prompt for the agent.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="instruction">The instruction text.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     instruction "You are a helpful assistant that answers questions about AWS."
+    /// }
+    /// </code>
+    [<CustomOperation("instruction")>]
+    member _.Instruction(config: BedrockAgentConfig, instruction: string) =
+        { config with
+            Instruction = Some instruction }
+
+    /// <summary>Sets the description for the agent.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="description">The agent description.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     description "An agent for customer support"
+    /// }
+    /// </code>
+    [<CustomOperation("description")>]
+    member _.Description(config: BedrockAgentConfig, description: string) =
+        { config with
+            Description = Some description }
+
+    /// <summary>Sets the IAM role ARN for the agent.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="roleArn">The IAM role ARN.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     agentResourceRoleArn "arn:aws:iam::123456789012:role/BedrockAgentRole"
+    /// }
+    /// </code>
+    [<CustomOperation("agentResourceRoleArn")>]
+    member _.AgentResourceRoleArn(config: BedrockAgentConfig, roleArn: string) =
+        { config with
+            AgentResourceRoleArn = Some roleArn }
+
+    /// <summary>Sets the idle session TTL in seconds.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="seconds">Idle session timeout in seconds.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     idleSessionTtlInSeconds 600
+    /// }
+    /// </code>
+    [<CustomOperation("idleSessionTtlInSeconds")>]
+    member _.IdleSessionTtlInSeconds(config: BedrockAgentConfig, seconds: int) =
+        { config with
+            IdleSessionTtlInSeconds = Some seconds }
+
+    /// <summary>Sets whether the agent should be auto-prepared after creation (default: true).</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="value">True to auto-prepare.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     autoPrepare true
+    /// }
+    /// </code>
+    [<CustomOperation("autoPrepare")>]
+    member _.AutoPrepare(config: BedrockAgentConfig, value: bool) =
+        { config with AutoPrepare = Some value }
+
+    /// <summary>Sets the KMS key ARN for customer-managed encryption.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="keyArn">The KMS key ARN.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     customerEncryptionKeyArn "arn:aws:kms:us-east-1:123456789012:key/my-key"
+    /// }
+    /// </code>
+    [<CustomOperation("customerEncryptionKeyArn")>]
+    member _.CustomerEncryptionKeyArn(config: BedrockAgentConfig, keyArn: string) =
+        { config with
+            CustomerEncryptionKeyArn = Some keyArn }
+
+    /// <summary>Sets whether to skip the resource-in-use check on delete.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="value">True to skip the check.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     skipResourceInUseCheckOnDelete true
+    /// }
+    /// </code>
+    [<CustomOperation("skipResourceInUseCheckOnDelete")>]
+    member _.SkipResourceInUseCheckOnDelete(config: BedrockAgentConfig, value: bool) =
+        { config with
+            SkipResourceInUseCheckOnDelete = Some value }
+
+    /// <summary>Adds tags to the agent.</summary>
+    /// <param name="config">The agent configuration.</param>
+    /// <param name="tags">List of key-value tag pairs.</param>
+    /// <code lang="fsharp">
+    /// bedrockAgent "MyAgent" {
+    ///     tags [ "Environment", "Production"; "Team", "AI" ]
+    /// }
+    /// </code>
+    [<CustomOperation("tags")>]
+    member _.Tags(config: BedrockAgentConfig, tags: (string * string) list) =
+        { config with
+            Tags = tags @ config.Tags }
+
+// ----------------------------------------------------------------------------
+// Bedrock Knowledge Base
+// ----------------------------------------------------------------------------
+
+/// <summary>Configuration for a Bedrock Knowledge Base resource.</summary>
+type BedrockKnowledgeBaseConfig =
+    { KnowledgeBaseName: string
+      ConstructId: string option
+      Description: string option
+      RoleArn: string option
+      KnowledgeBaseConfiguration: obj option
+      StorageConfiguration: obj option
+      Tags: (string * string) list }
+
+/// <summary>Spec for a Bedrock Knowledge Base, holding the resolved props and mutable resource reference.</summary>
+type BedrockKnowledgeBaseSpec =
+    { KnowledgeBaseName: string
+      ConstructId: string
+      Props: CfnKnowledgeBaseProps
+      mutable KnowledgeBase: CfnKnowledgeBase option }
+
+type BedrockKnowledgeBaseBuilder(name: string) =
+    member _.Yield(_: unit) : BedrockKnowledgeBaseConfig =
+        { KnowledgeBaseName = name
+          ConstructId = None
+          Description = None
+          RoleArn = None
+          KnowledgeBaseConfiguration = None
+          StorageConfiguration = None
+          Tags = [] }
+
+    member _.Zero() : BedrockKnowledgeBaseConfig =
+        { KnowledgeBaseName = name
+          ConstructId = None
+          Description = None
+          RoleArn = None
+          KnowledgeBaseConfiguration = None
+          StorageConfiguration = None
+          Tags = [] }
+
+    member inline _.Delay([<InlineIfLambda>] f: unit -> BedrockKnowledgeBaseConfig) : BedrockKnowledgeBaseConfig = f ()
+
+    member _.Combine
+        (
+            state1: BedrockKnowledgeBaseConfig,
+            state2: BedrockKnowledgeBaseConfig
+        ) : BedrockKnowledgeBaseConfig =
+        { KnowledgeBaseName = state2.KnowledgeBaseName
+          ConstructId = state2.ConstructId |> Option.orElse state1.ConstructId
+          Description = state2.Description |> Option.orElse state1.Description
+          RoleArn = state2.RoleArn |> Option.orElse state1.RoleArn
+          KnowledgeBaseConfiguration =
+            state2.KnowledgeBaseConfiguration
+            |> Option.orElse state1.KnowledgeBaseConfiguration
+          StorageConfiguration = state2.StorageConfiguration |> Option.orElse state1.StorageConfiguration
+          Tags =
+            if state2.Tags.IsEmpty then
+                state1.Tags
+            else
+                state2.Tags @ state1.Tags }
+
+    member inline x.For
+        (
+            config: BedrockKnowledgeBaseConfig,
+            [<InlineIfLambda>] f: unit -> BedrockKnowledgeBaseConfig
+        ) : BedrockKnowledgeBaseConfig =
+        let newConfig = f ()
+        x.Combine(config, newConfig)
+
+    member _.Run(config: BedrockKnowledgeBaseConfig) : BedrockKnowledgeBaseSpec =
+        let constructId = config.ConstructId |> Option.defaultValue config.KnowledgeBaseName
+
+        let props = CfnKnowledgeBaseProps()
+
+        props.Name <- config.KnowledgeBaseName
+
+        props.RoleArn <-
+            match config.RoleArn with
+            | Some r -> r
+            | None -> failwith "Bedrock Knowledge Base roleArn is required"
+
+        props.KnowledgeBaseConfiguration <-
+            match config.KnowledgeBaseConfiguration with
+            | Some c -> c
+            | None -> failwith "Bedrock Knowledge Base knowledgeBaseConfiguration is required"
+
+        props.StorageConfiguration <-
+            match config.StorageConfiguration with
+            | Some s -> s
+            | None -> failwith "Bedrock Knowledge Base storageConfiguration is required"
+
+        config.Description |> Option.iter (fun d -> props.Description <- d)
+
+        if not (List.isEmpty config.Tags) then
+            let tagDict = Dictionary<string, string>()
+
+            for key, value in config.Tags do
+                tagDict[key] <- value
+
+            props.Tags <- tagDict
+
+        { KnowledgeBaseName = config.KnowledgeBaseName
+          ConstructId = constructId
+          Props = props
+          KnowledgeBase = None }
+
+    /// <summary>Sets the construct ID for the knowledge base.</summary>
+    /// <param name="config">The knowledge base configuration.</param>
+    /// <param name="id">The construct ID.</param>
+    /// <code lang="fsharp">
+    /// bedrockKnowledgeBase "MyKB" {
+    ///     constructId "MyKBConstruct"
+    /// }
+    /// </code>
+    [<CustomOperation("constructId")>]
+    member _.ConstructId(config: BedrockKnowledgeBaseConfig, id: string) = { config with ConstructId = Some id }
+
+    /// <summary>Sets the description for the knowledge base.</summary>
+    /// <param name="config">The knowledge base configuration.</param>
+    /// <param name="description">The description.</param>
+    /// <code lang="fsharp">
+    /// bedrockKnowledgeBase "MyKB" {
+    ///     description "Knowledge base for product documentation"
+    /// }
+    /// </code>
+    [<CustomOperation("description")>]
+    member _.Description(config: BedrockKnowledgeBaseConfig, description: string) =
+        { config with
+            Description = Some description }
+
+    /// <summary>Sets the IAM role ARN for the knowledge base.</summary>
+    /// <param name="config">The knowledge base configuration.</param>
+    /// <param name="roleArn">The IAM role ARN.</param>
+    /// <code lang="fsharp">
+    /// bedrockKnowledgeBase "MyKB" {
+    ///     roleArn "arn:aws:iam::123456789012:role/BedrockKBRole"
+    /// }
+    /// </code>
+    [<CustomOperation("roleArn")>]
+    member _.RoleArn(config: BedrockKnowledgeBaseConfig, roleArn: string) = { config with RoleArn = Some roleArn }
+
+    /// <summary>Sets the knowledge base configuration (embedding model, type, etc.).</summary>
+    /// <param name="config">The knowledge base configuration.</param>
+    /// <param name="kbConfig">The CfnKnowledgeBase.IKnowledgeBaseConfigurationProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockKnowledgeBase "MyKB" {
+    ///     knowledgeBaseConfiguration myKBConfig
+    /// }
+    /// </code>
+    [<CustomOperation("knowledgeBaseConfiguration")>]
+    member _.KnowledgeBaseConfiguration
+        (
+            config: BedrockKnowledgeBaseConfig,
+            kbConfig: CfnKnowledgeBase.IKnowledgeBaseConfigurationProperty
+        ) =
+        { config with
+            KnowledgeBaseConfiguration = Some(kbConfig :> obj) }
+
+    /// <summary>Sets the storage configuration (vector store backend).</summary>
+    /// <param name="config">The knowledge base configuration.</param>
+    /// <param name="storageConfig">The CfnKnowledgeBase.IStorageConfigurationProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockKnowledgeBase "MyKB" {
+    ///     storageConfiguration myStorageConfig
+    /// }
+    /// </code>
+    [<CustomOperation("storageConfiguration")>]
+    member _.StorageConfiguration
+        (
+            config: BedrockKnowledgeBaseConfig,
+            storageConfig: CfnKnowledgeBase.IStorageConfigurationProperty
+        ) =
+        { config with
+            StorageConfiguration = Some(storageConfig :> obj) }
+
+    /// <summary>Adds tags to the knowledge base.</summary>
+    /// <param name="config">The knowledge base configuration.</param>
+    /// <param name="tags">List of key-value tag pairs.</param>
+    /// <code lang="fsharp">
+    /// bedrockKnowledgeBase "MyKB" {
+    ///     tags [ "Environment", "Production" ]
+    /// }
+    /// </code>
+    [<CustomOperation("tags")>]
+    member _.Tags(config: BedrockKnowledgeBaseConfig, tags: (string * string) list) =
+        { config with
+            Tags = tags @ config.Tags }
+
+// ----------------------------------------------------------------------------
+// Bedrock Data Source
+// ----------------------------------------------------------------------------
+
+/// <summary>Configuration for a Bedrock Data Source resource.</summary>
+type BedrockDataSourceConfig =
+    { DataSourceName: string
+      ConstructId: string option
+      KnowledgeBaseId: string option
+      Description: string option
+      DataSourceConfiguration: obj option
+      DataDeletionPolicy: string option
+      ServerSideEncryptionConfiguration: obj option
+      VectorIngestionConfiguration: obj option }
+
+/// <summary>Spec for a Bedrock Data Source, holding the resolved props and mutable resource reference.</summary>
+type BedrockDataSourceSpec =
+    { DataSourceName: string
+      ConstructId: string
+      Props: CfnDataSourceProps
+      mutable DataSource: CfnDataSource option }
+
+type BedrockDataSourceBuilder(name: string) =
+    member _.Yield(_: unit) : BedrockDataSourceConfig =
+        { DataSourceName = name
+          ConstructId = None
+          KnowledgeBaseId = None
+          Description = None
+          DataSourceConfiguration = None
+          DataDeletionPolicy = None
+          ServerSideEncryptionConfiguration = None
+          VectorIngestionConfiguration = None }
+
+    member _.Zero() : BedrockDataSourceConfig =
+        { DataSourceName = name
+          ConstructId = None
+          KnowledgeBaseId = None
+          Description = None
+          DataSourceConfiguration = None
+          DataDeletionPolicy = None
+          ServerSideEncryptionConfiguration = None
+          VectorIngestionConfiguration = None }
+
+    member inline _.Delay([<InlineIfLambda>] f: unit -> BedrockDataSourceConfig) : BedrockDataSourceConfig = f ()
+
+    member _.Combine(state1: BedrockDataSourceConfig, state2: BedrockDataSourceConfig) : BedrockDataSourceConfig =
+        { DataSourceName = state2.DataSourceName
+          ConstructId = state2.ConstructId |> Option.orElse state1.ConstructId
+          KnowledgeBaseId = state2.KnowledgeBaseId |> Option.orElse state1.KnowledgeBaseId
+          Description = state2.Description |> Option.orElse state1.Description
+          DataSourceConfiguration = state2.DataSourceConfiguration |> Option.orElse state1.DataSourceConfiguration
+          DataDeletionPolicy = state2.DataDeletionPolicy |> Option.orElse state1.DataDeletionPolicy
+          ServerSideEncryptionConfiguration =
+            state2.ServerSideEncryptionConfiguration
+            |> Option.orElse state1.ServerSideEncryptionConfiguration
+          VectorIngestionConfiguration =
+            state2.VectorIngestionConfiguration
+            |> Option.orElse state1.VectorIngestionConfiguration }
+
+    member inline x.For
+        (
+            config: BedrockDataSourceConfig,
+            [<InlineIfLambda>] f: unit -> BedrockDataSourceConfig
+        ) : BedrockDataSourceConfig =
+        let newConfig = f ()
+        x.Combine(config, newConfig)
+
+    member _.Run(config: BedrockDataSourceConfig) : BedrockDataSourceSpec =
+        let constructId = config.ConstructId |> Option.defaultValue config.DataSourceName
+
+        let props = CfnDataSourceProps()
+
+        props.Name <- config.DataSourceName
+
+        props.KnowledgeBaseId <-
+            match config.KnowledgeBaseId with
+            | Some id -> id
+            | None -> failwith "Bedrock Data Source knowledgeBaseId is required"
+
+        props.DataSourceConfiguration <-
+            match config.DataSourceConfiguration with
+            | Some c -> c
+            | None -> failwith "Bedrock Data Source dataSourceConfiguration is required"
+
+        config.Description |> Option.iter (fun d -> props.Description <- d)
+
+        config.DataDeletionPolicy
+        |> Option.iter (fun p -> props.DataDeletionPolicy <- p)
+
+        config.ServerSideEncryptionConfiguration
+        |> Option.iter (fun s -> props.ServerSideEncryptionConfiguration <- s)
+
+        config.VectorIngestionConfiguration
+        |> Option.iter (fun v -> props.VectorIngestionConfiguration <- v)
+
+        { DataSourceName = config.DataSourceName
+          ConstructId = constructId
+          Props = props
+          DataSource = None }
+
+    /// <summary>Sets the construct ID for the data source.</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="id">The construct ID.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     constructId "MyDSConstruct"
+    /// }
+    /// </code>
+    [<CustomOperation("constructId")>]
+    member _.ConstructId(config: BedrockDataSourceConfig, id: string) = { config with ConstructId = Some id }
+
+    /// <summary>Sets the knowledge base ID this data source belongs to.</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="id">The knowledge base ID.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     knowledgeBaseId "KB12345"
+    /// }
+    /// </code>
+    [<CustomOperation("knowledgeBaseId")>]
+    member _.KnowledgeBaseId(config: BedrockDataSourceConfig, id: string) =
+        { config with
+            KnowledgeBaseId = Some id }
+
+    /// <summary>Sets the description for the data source.</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="description">The description.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     description "S3 data source for product docs"
+    /// }
+    /// </code>
+    [<CustomOperation("description")>]
+    member _.Description(config: BedrockDataSourceConfig, description: string) =
+        { config with
+            Description = Some description }
+
+    /// <summary>Sets the data source configuration (S3, web, etc.).</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="dsConfig">The CfnDataSource.IDataSourceConfigurationProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     dataSourceConfiguration myDSConfig
+    /// }
+    /// </code>
+    [<CustomOperation("dataSourceConfiguration")>]
+    member _.DataSourceConfiguration
+        (
+            config: BedrockDataSourceConfig,
+            dsConfig: CfnDataSource.IDataSourceConfigurationProperty
+        ) =
+        { config with
+            DataSourceConfiguration = Some(dsConfig :> obj) }
+
+    /// <summary>Sets the data deletion policy (RETAIN or DELETE).</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="policy">The deletion policy string.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     dataDeletionPolicy "RETAIN"
+    /// }
+    /// </code>
+    [<CustomOperation("dataDeletionPolicy")>]
+    member _.DataDeletionPolicy(config: BedrockDataSourceConfig, policy: string) =
+        { config with
+            DataDeletionPolicy = Some policy }
+
+    /// <summary>Sets the server-side encryption configuration.</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="encryptionConfig">The CfnDataSource.IServerSideEncryptionConfigurationProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     serverSideEncryptionConfiguration myEncConfig
+    /// }
+    /// </code>
+    [<CustomOperation("serverSideEncryptionConfiguration")>]
+    member _.ServerSideEncryptionConfiguration
+        (
+            config: BedrockDataSourceConfig,
+            encryptionConfig: CfnDataSource.IServerSideEncryptionConfigurationProperty
+        ) =
+        { config with
+            ServerSideEncryptionConfiguration = Some(encryptionConfig :> obj) }
+
+    /// <summary>Sets the vector ingestion configuration (chunking strategy, etc.).</summary>
+    /// <param name="config">The data source configuration.</param>
+    /// <param name="ingestionConfig">The CfnDataSource.IVectorIngestionConfigurationProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockDataSource "MyDS" {
+    ///     vectorIngestionConfiguration myIngestionConfig
+    /// }
+    /// </code>
+    [<CustomOperation("vectorIngestionConfiguration")>]
+    member _.VectorIngestionConfiguration
+        (
+            config: BedrockDataSourceConfig,
+            ingestionConfig: CfnDataSource.IVectorIngestionConfigurationProperty
+        ) =
+        { config with
+            VectorIngestionConfiguration = Some(ingestionConfig :> obj) }
+
+// ----------------------------------------------------------------------------
+// Bedrock Guardrail
+// ----------------------------------------------------------------------------
+
+/// <summary>Configuration for a Bedrock Guardrail resource.</summary>
+type BedrockGuardrailConfig =
+    { GuardrailName: string
+      ConstructId: string option
+      Description: string option
+      BlockedInputMessaging: string option
+      BlockedOutputsMessaging: string option
+      ContentPolicyConfig: obj option
+      ContextualGroundingPolicyConfig: obj option
+      SensitiveInformationPolicyConfig: obj option
+      TopicPolicyConfig: obj option
+      WordPolicyConfig: obj option
+      KmsKeyArn: string option
+      Tags: (string * string) list }
+
+/// <summary>Spec for a Bedrock Guardrail, holding the resolved props and mutable resource reference.</summary>
+type BedrockGuardrailSpec =
+    { GuardrailName: string
+      ConstructId: string
+      Props: CfnGuardrailProps
+      mutable Guardrail: CfnGuardrail option }
+
+type BedrockGuardrailBuilder(name: string) =
+    member _.Yield(_: unit) : BedrockGuardrailConfig =
+        { GuardrailName = name
+          ConstructId = None
+          Description = None
+          BlockedInputMessaging = None
+          BlockedOutputsMessaging = None
+          ContentPolicyConfig = None
+          ContextualGroundingPolicyConfig = None
+          SensitiveInformationPolicyConfig = None
+          TopicPolicyConfig = None
+          WordPolicyConfig = None
+          KmsKeyArn = None
+          Tags = [] }
+
+    member _.Zero() : BedrockGuardrailConfig =
+        { GuardrailName = name
+          ConstructId = None
+          Description = None
+          BlockedInputMessaging = None
+          BlockedOutputsMessaging = None
+          ContentPolicyConfig = None
+          ContextualGroundingPolicyConfig = None
+          SensitiveInformationPolicyConfig = None
+          TopicPolicyConfig = None
+          WordPolicyConfig = None
+          KmsKeyArn = None
+          Tags = [] }
+
+    member inline _.Delay([<InlineIfLambda>] f: unit -> BedrockGuardrailConfig) : BedrockGuardrailConfig = f ()
+
+    member _.Combine(state1: BedrockGuardrailConfig, state2: BedrockGuardrailConfig) : BedrockGuardrailConfig =
+        { GuardrailName = state2.GuardrailName
+          ConstructId = state2.ConstructId |> Option.orElse state1.ConstructId
+          Description = state2.Description |> Option.orElse state1.Description
+          BlockedInputMessaging = state2.BlockedInputMessaging |> Option.orElse state1.BlockedInputMessaging
+          BlockedOutputsMessaging = state2.BlockedOutputsMessaging |> Option.orElse state1.BlockedOutputsMessaging
+          ContentPolicyConfig = state2.ContentPolicyConfig |> Option.orElse state1.ContentPolicyConfig
+          ContextualGroundingPolicyConfig =
+            state2.ContextualGroundingPolicyConfig
+            |> Option.orElse state1.ContextualGroundingPolicyConfig
+          SensitiveInformationPolicyConfig =
+            state2.SensitiveInformationPolicyConfig
+            |> Option.orElse state1.SensitiveInformationPolicyConfig
+          TopicPolicyConfig = state2.TopicPolicyConfig |> Option.orElse state1.TopicPolicyConfig
+          WordPolicyConfig = state2.WordPolicyConfig |> Option.orElse state1.WordPolicyConfig
+          KmsKeyArn = state2.KmsKeyArn |> Option.orElse state1.KmsKeyArn
+          Tags =
+            if state2.Tags.IsEmpty then
+                state1.Tags
+            else
+                state2.Tags @ state1.Tags }
+
+    member inline x.For
+        (
+            config: BedrockGuardrailConfig,
+            [<InlineIfLambda>] f: unit -> BedrockGuardrailConfig
+        ) : BedrockGuardrailConfig =
+        let newConfig = f ()
+        x.Combine(config, newConfig)
+
+    member _.Run(config: BedrockGuardrailConfig) : BedrockGuardrailSpec =
+        let constructId = config.ConstructId |> Option.defaultValue config.GuardrailName
+
+        let props = CfnGuardrailProps()
+
+        props.Name <- config.GuardrailName
+
+        props.BlockedInputMessaging <-
+            match config.BlockedInputMessaging with
+            | Some m -> m
+            | None -> failwith "Bedrock Guardrail blockedInputMessaging is required"
+
+        props.BlockedOutputsMessaging <-
+            match config.BlockedOutputsMessaging with
+            | Some m -> m
+            | None -> failwith "Bedrock Guardrail blockedOutputsMessaging is required"
+
+        config.Description |> Option.iter (fun d -> props.Description <- d)
+
+        config.ContentPolicyConfig
+        |> Option.iter (fun c -> props.ContentPolicyConfig <- c)
+
+        config.ContextualGroundingPolicyConfig
+        |> Option.iter (fun c -> props.ContextualGroundingPolicyConfig <- c)
+
+        config.SensitiveInformationPolicyConfig
+        |> Option.iter (fun s -> props.SensitiveInformationPolicyConfig <- s)
+
+        config.TopicPolicyConfig |> Option.iter (fun t -> props.TopicPolicyConfig <- t)
+        config.WordPolicyConfig |> Option.iter (fun w -> props.WordPolicyConfig <- w)
+        config.KmsKeyArn |> Option.iter (fun k -> props.KmsKeyArn <- k)
+
+        if not (List.isEmpty config.Tags) then
+            props.Tags <-
+                config.Tags
+                |> List.map (fun (k, v) -> CfnTag(Key = k, Value = v) :> ICfnTag)
+                |> Array.ofList
+
+        { GuardrailName = config.GuardrailName
+          ConstructId = constructId
+          Props = props
+          Guardrail = None }
+
+    /// <summary>Sets the construct ID for the guardrail.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="id">The construct ID.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     constructId "MyGuardrailConstruct"
+    /// }
+    /// </code>
+    [<CustomOperation("constructId")>]
+    member _.ConstructId(config: BedrockGuardrailConfig, id: string) = { config with ConstructId = Some id }
+
+    /// <summary>Sets the description for the guardrail.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="description">The description.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     description "Content safety guardrail"
+    /// }
+    /// </code>
+    [<CustomOperation("description")>]
+    member _.Description(config: BedrockGuardrailConfig, description: string) =
+        { config with
+            Description = Some description }
+
+    /// <summary>Sets the message shown when input is blocked.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="message">The blocked input message.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     blockedInputMessaging "Your input was blocked by the guardrail."
+    /// }
+    /// </code>
+    [<CustomOperation("blockedInputMessaging")>]
+    member _.BlockedInputMessaging(config: BedrockGuardrailConfig, message: string) =
+        { config with
+            BlockedInputMessaging = Some message }
+
+    /// <summary>Sets the message shown when output is blocked.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="message">The blocked output message.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     blockedOutputsMessaging "The response was blocked by the guardrail."
+    /// }
+    /// </code>
+    [<CustomOperation("blockedOutputsMessaging")>]
+    member _.BlockedOutputsMessaging(config: BedrockGuardrailConfig, message: string) =
+        { config with
+            BlockedOutputsMessaging = Some message }
+
+    /// <summary>Sets the content policy configuration (content filters).</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="policyConfig">The CfnGuardrail.IContentPolicyConfigProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     contentPolicyConfig myContentPolicy
+    /// }
+    /// </code>
+    [<CustomOperation("contentPolicyConfig")>]
+    member _.ContentPolicyConfig
+        (
+            config: BedrockGuardrailConfig,
+            policyConfig: CfnGuardrail.IContentPolicyConfigProperty
+        ) =
+        { config with
+            ContentPolicyConfig = Some(policyConfig :> obj) }
+
+    /// <summary>Sets the contextual grounding policy configuration.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="policyConfig">The CfnGuardrail.IContextualGroundingPolicyConfigProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     contextualGroundingPolicyConfig myGroundingPolicy
+    /// }
+    /// </code>
+    [<CustomOperation("contextualGroundingPolicyConfig")>]
+    member _.ContextualGroundingPolicyConfig
+        (
+            config: BedrockGuardrailConfig,
+            policyConfig: CfnGuardrail.IContextualGroundingPolicyConfigProperty
+        ) =
+        { config with
+            ContextualGroundingPolicyConfig = Some(policyConfig :> obj) }
+
+    /// <summary>Sets the sensitive information policy configuration (PII filters).</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="policyConfig">The CfnGuardrail.ISensitiveInformationPolicyConfigProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     sensitiveInformationPolicyConfig myPIIPolicy
+    /// }
+    /// </code>
+    [<CustomOperation("sensitiveInformationPolicyConfig")>]
+    member _.SensitiveInformationPolicyConfig
+        (
+            config: BedrockGuardrailConfig,
+            policyConfig: CfnGuardrail.ISensitiveInformationPolicyConfigProperty
+        ) =
+        { config with
+            SensitiveInformationPolicyConfig = Some(policyConfig :> obj) }
+
+    /// <summary>Sets the topic policy configuration (denied topics).</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="policyConfig">The CfnGuardrail.ITopicPolicyConfigProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     topicPolicyConfig myTopicPolicy
+    /// }
+    /// </code>
+    [<CustomOperation("topicPolicyConfig")>]
+    member _.TopicPolicyConfig(config: BedrockGuardrailConfig, policyConfig: CfnGuardrail.ITopicPolicyConfigProperty) =
+        { config with
+            TopicPolicyConfig = Some(policyConfig :> obj) }
+
+    /// <summary>Sets the word policy configuration (blocked words/phrases).</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="policyConfig">The CfnGuardrail.IWordPolicyConfigProperty.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     wordPolicyConfig myWordPolicy
+    /// }
+    /// </code>
+    [<CustomOperation("wordPolicyConfig")>]
+    member _.WordPolicyConfig(config: BedrockGuardrailConfig, policyConfig: CfnGuardrail.IWordPolicyConfigProperty) =
+        { config with
+            WordPolicyConfig = Some(policyConfig :> obj) }
+
+    /// <summary>Sets the KMS key ARN for encrypting the guardrail.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="keyArn">The KMS key ARN.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     kmsKeyArn "arn:aws:kms:us-east-1:123456789012:key/my-key"
+    /// }
+    /// </code>
+    [<CustomOperation("kmsKeyArn")>]
+    member _.KmsKeyArn(config: BedrockGuardrailConfig, keyArn: string) = { config with KmsKeyArn = Some keyArn }
+
+    /// <summary>Adds tags to the guardrail.</summary>
+    /// <param name="config">The guardrail configuration.</param>
+    /// <param name="tags">List of key-value tag pairs.</param>
+    /// <code lang="fsharp">
+    /// bedrockGuardrail "MyGuardrail" {
+    ///     tags [ "Environment", "Production"; "Team", "AI" ]
+    /// }
+    /// </code>
+    [<CustomOperation("tags")>]
+    member _.Tags(config: BedrockGuardrailConfig, tags: (string * string) list) =
+        { config with
+            Tags = tags @ config.Tags }
+
+// ============================================================================
+// Builders
+// ============================================================================
+
+[<AutoOpen>]
+module BedrockBuilders =
+    /// <summary>
+    /// Creates a new Bedrock Agent builder.
+    /// Example: bedrockAgent "MyAgent" { foundationModel "anthropic.claude-3-sonnet-20240229-v1:0" }
+    /// </summary>
+    let bedrockAgent name = BedrockAgentBuilder name
+
+    /// <summary>
+    /// Creates a new Bedrock Knowledge Base builder.
+    /// Example: bedrockKnowledgeBase "MyKB" { roleArn "..." }
+    /// </summary>
+    let bedrockKnowledgeBase name = BedrockKnowledgeBaseBuilder name
+
+    /// <summary>
+    /// Creates a new Bedrock Data Source builder.
+    /// Example: bedrockDataSource "MyDS" { knowledgeBaseId "..." }
+    /// </summary>
+    let bedrockDataSource name = BedrockDataSourceBuilder name
+
+    /// <summary>
+    /// Creates a new Bedrock Guardrail builder.
+    /// Example: bedrockGuardrail "MyGuardrail" { blockedInputMessaging "..." }
+    /// </summary>
+    let bedrockGuardrail name = BedrockGuardrailBuilder name

--- a/src/FsCDK.fsproj
+++ b/src/FsCDK.fsproj
@@ -73,6 +73,7 @@
       <Compile Include="Kinesis.fs" />
       <Compile Include="CloudHSM.fs" />
       <Compile Include="CloudTrail.fs" />
+      <Compile Include="Bedrock.fs" />
 
       <Compile Include="Stack.fs" />
 

--- a/src/Stack.fs
+++ b/src/Stack.fs
@@ -30,6 +30,7 @@ open Amazon.CDK.AWS.APIGateway
 open Amazon.CDK.AWS.ECS
 open Amazon.CDK.AWS.CloudTrail
 open Amazon.CDK.AWS.SSM
+open Amazon.CDK.AwsBedrock
 //open Amazon.CDK.AWS.CloudHSMV2
 
 // ============================================================================
@@ -105,6 +106,10 @@ type Operation =
     | UserOp of UserSpec
     | SSMParameterOp of SSMParameterSpec
     | SSMDocumentOp of SSMDocumentSpec
+    | BedrockAgentOp of BedrockAgentSpec
+    | BedrockKnowledgeBaseOp of BedrockKnowledgeBaseSpec
+    | BedrockDataSourceOp of BedrockDataSourceSpec
+    | BedrockGuardrailOp of BedrockGuardrailSpec
 
 // ============================================================================
 // Helper Functions - Process Operations in Stack
@@ -585,6 +590,22 @@ module StackOperations =
 
             ssmDocumentSpec.Document <- Some document
 
+        | BedrockAgentOp agentSpec ->
+            let agent = CfnAgent(stack, agentSpec.ConstructId, agentSpec.Props)
+            agentSpec.Agent <- Some agent
+
+        | BedrockKnowledgeBaseOp kbSpec ->
+            let kb = CfnKnowledgeBase(stack, kbSpec.ConstructId, kbSpec.Props)
+            kbSpec.KnowledgeBase <- Some kb
+
+        | BedrockDataSourceOp dsSpec ->
+            let ds = CfnDataSource(stack, dsSpec.ConstructId, dsSpec.Props)
+            dsSpec.DataSource <- Some ds
+
+        | BedrockGuardrailOp grSpec ->
+            let gr = CfnGuardrail(stack, grSpec.ConstructId, grSpec.Props)
+            grSpec.Guardrail <- Some gr
+
 
 // ============================================================================
 // Stack and App Configuration DSL
@@ -1042,9 +1063,60 @@ type StackBuilder(name: string) =
     member inline this.Bind(spec: UserSpec, [<InlineIfLambda>] cont: IUser -> StackConfig) : StackConfig =
         this.BindViaYield UserOp (fun s -> s.User) "User" (fun s -> s.ConstructId) spec cont
 
+    member inline this.Bind(spec: BedrockAgentSpec, [<InlineIfLambda>] cont: CfnAgent -> StackConfig) : StackConfig =
+        this.BindViaYield BedrockAgentOp (fun s -> s.Agent) "Bedrock Agent" (fun s -> s.AgentName) spec cont
+
+    member inline this.Bind
+        (
+            spec: BedrockKnowledgeBaseSpec,
+            [<InlineIfLambda>] cont: CfnKnowledgeBase -> StackConfig
+        ) : StackConfig =
+        this.BindViaYield
+            BedrockKnowledgeBaseOp
+            (fun s -> s.KnowledgeBase)
+            "Bedrock Knowledge Base"
+            (fun s -> s.KnowledgeBaseName)
+            spec
+            cont
+
+    member inline this.Bind
+        (
+            spec: BedrockDataSourceSpec,
+            [<InlineIfLambda>] cont: CfnDataSource -> StackConfig
+        ) : StackConfig =
+        this.BindViaYield
+            BedrockDataSourceOp
+            (fun s -> s.DataSource)
+            "Bedrock Data Source"
+            (fun s -> s.DataSourceName)
+            spec
+            cont
+
+    member inline this.Bind
+        (
+            spec: BedrockGuardrailSpec,
+            [<InlineIfLambda>] cont: CfnGuardrail -> StackConfig
+        ) : StackConfig =
+        this.BindViaYield
+            BedrockGuardrailOp
+            (fun s -> s.Guardrail)
+            "Bedrock Guardrail"
+            (fun s -> s.GuardrailName)
+            spec
+            cont
+
     member this.Yield(trailSpec: CloudTrailSpec) : StackConfig = this.Init(CloudTrailOp trailSpec)
 
     member this.Yield(trailSpec: EfsFileSystemSpec) : StackConfig = this.Init(EfsFileSystemOp trailSpec)
+
+    member this.Yield(agentSpec: BedrockAgentSpec) : StackConfig = this.Init(BedrockAgentOp agentSpec)
+
+    member this.Yield(kbSpec: BedrockKnowledgeBaseSpec) : StackConfig =
+        this.Init(BedrockKnowledgeBaseOp kbSpec)
+
+    member this.Yield(dsSpec: BedrockDataSourceSpec) : StackConfig = this.Init(BedrockDataSourceOp dsSpec)
+
+    member this.Yield(grSpec: BedrockGuardrailSpec) : StackConfig = this.Init(BedrockGuardrailOp grSpec)
 
     member _.Zero() : StackConfig =
         { Name = name

--- a/tests/BedrockTests.fs
+++ b/tests/BedrockTests.fs
@@ -1,0 +1,390 @@
+module FsCDK.Tests.BedrockTests
+
+open Expecto
+open FsCDK
+open Amazon.CDK.AwsBedrock
+
+[<Tests>]
+let bedrockAgentTests =
+    testList
+        "Bedrock Agent DSL"
+        [ test "fails when foundation model is missing" {
+              let thrower () =
+                  bedrockAgent "MyAgent" { () } |> ignore
+
+              Expect.throws thrower "Bedrock Agent builder should throw when foundation model is missing"
+          }
+
+          test "sets agent name" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                  }
+
+              Expect.equal spec.AgentName "MyAgent" "Agent name should match"
+          }
+
+          test "defaults constructId to agent name" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                  }
+
+              Expect.equal spec.ConstructId "MyAgent" "ConstructId should default to agent name"
+          }
+
+          test "sets custom constructId" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                      constructId "CustomId"
+                  }
+
+              Expect.equal spec.ConstructId "CustomId" "ConstructId should match custom value"
+          }
+
+          test "sets foundation model" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                  }
+
+              Expect.equal spec.Props.FoundationModel "anthropic.claude-3-sonnet-20240229-v1:0" "Foundation model should be set"
+          }
+
+          test "sets instruction" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                      instruction "You are a helpful assistant."
+                  }
+
+              Expect.equal spec.Props.Instruction "You are a helpful assistant." "Instruction should be set"
+          }
+
+          test "sets description" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                      description "A test agent"
+                  }
+
+              Expect.equal spec.Props.Description "A test agent" "Description should be set"
+          }
+
+          test "sets agentResourceRoleArn" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                      agentResourceRoleArn "arn:aws:iam::123456789012:role/BedrockAgentRole"
+                  }
+
+              Expect.equal
+                  spec.Props.AgentResourceRoleArn
+                  "arn:aws:iam::123456789012:role/BedrockAgentRole"
+                  "AgentResourceRoleArn should be set"
+          }
+
+          test "sets idleSessionTtlInSeconds" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                      idleSessionTtlInSeconds 600
+                  }
+
+              Expect.isNotNull (box spec.Props.IdleSessionTtlInSeconds) "IdleSessionTtlInSeconds should be set"
+          }
+
+          test "autoPrepare defaults to true" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                  }
+
+              Expect.isNotNull (box spec.Props.AutoPrepare) "AutoPrepare should be set"
+          }
+
+          test "mutable Agent starts as None" {
+              let spec =
+                  bedrockAgent "MyAgent" {
+                      foundationModel "anthropic.claude-3-sonnet-20240229-v1:0"
+                  }
+
+              Expect.isNone spec.Agent "Agent should start as None"
+          } ]
+    |> testSequenced
+
+[<Tests>]
+let bedrockKnowledgeBaseTests =
+    let dummyKBConfig =
+        CfnKnowledgeBase.KnowledgeBaseConfigurationProperty(Type = "VECTOR")
+
+    let dummyStorageConfig =
+        CfnKnowledgeBase.StorageConfigurationProperty(Type = "OPENSEARCH_SERVERLESS")
+
+    testList
+        "Bedrock Knowledge Base DSL"
+        [ test "fails when roleArn is missing" {
+              let thrower () =
+                  bedrockKnowledgeBase "MyKB" {
+                      knowledgeBaseConfiguration dummyKBConfig
+                      storageConfiguration dummyStorageConfig
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when roleArn is missing"
+          }
+
+          test "fails when knowledgeBaseConfiguration is missing" {
+              let thrower () =
+                  bedrockKnowledgeBase "MyKB" {
+                      roleArn "arn:aws:iam::123456789012:role/KBRole"
+                      storageConfiguration dummyStorageConfig
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when knowledgeBaseConfiguration is missing"
+          }
+
+          test "fails when storageConfiguration is missing" {
+              let thrower () =
+                  bedrockKnowledgeBase "MyKB" {
+                      roleArn "arn:aws:iam::123456789012:role/KBRole"
+                      knowledgeBaseConfiguration dummyKBConfig
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when storageConfiguration is missing"
+          }
+
+          test "fails when all required fields are missing" {
+              let thrower () =
+                  bedrockKnowledgeBase "MyKB" { () } |> ignore
+
+              Expect.throws thrower "Should throw when all required fields are missing"
+          }
+
+          test "sets knowledge base name" {
+              let spec =
+                  bedrockKnowledgeBase "MyKB" {
+                      roleArn "arn:aws:iam::123456789012:role/KBRole"
+                      knowledgeBaseConfiguration dummyKBConfig
+                      storageConfiguration dummyStorageConfig
+                  }
+
+              Expect.equal spec.KnowledgeBaseName "MyKB" "Knowledge base name should match"
+          }
+
+          test "sets description" {
+              let spec =
+                  bedrockKnowledgeBase "MyKB" {
+                      roleArn "arn:aws:iam::123456789012:role/KBRole"
+                      knowledgeBaseConfiguration dummyKBConfig
+                      storageConfiguration dummyStorageConfig
+                      description "Product docs KB"
+                  }
+
+              Expect.equal spec.Props.Description "Product docs KB" "Description should be set"
+          }
+
+          test "mutable KnowledgeBase starts as None" {
+              let spec =
+                  bedrockKnowledgeBase "MyKB" {
+                      roleArn "arn:aws:iam::123456789012:role/KBRole"
+                      knowledgeBaseConfiguration dummyKBConfig
+                      storageConfiguration dummyStorageConfig
+                  }
+
+              Expect.isNone spec.KnowledgeBase "KnowledgeBase should start as None"
+          } ]
+    |> testSequenced
+
+[<Tests>]
+let bedrockDataSourceTests =
+    let dummyDSConfig =
+        CfnDataSource.DataSourceConfigurationProperty(Type = "S3")
+
+    testList
+        "Bedrock Data Source DSL"
+        [ test "fails when knowledgeBaseId is missing" {
+              let thrower () =
+                  bedrockDataSource "MyDS" {
+                      dataSourceConfiguration dummyDSConfig
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when knowledgeBaseId is missing"
+          }
+
+          test "fails when dataSourceConfiguration is missing" {
+              let thrower () =
+                  bedrockDataSource "MyDS" {
+                      knowledgeBaseId "KB123"
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when dataSourceConfiguration is missing"
+          }
+
+          test "fails when all required fields are missing" {
+              let thrower () =
+                  bedrockDataSource "MyDS" { () } |> ignore
+
+              Expect.throws thrower "Should throw when all required fields are missing"
+          }
+
+          test "sets data source name" {
+              let spec =
+                  bedrockDataSource "MyDS" {
+                      knowledgeBaseId "KB123"
+                      dataSourceConfiguration dummyDSConfig
+                  }
+
+              Expect.equal spec.DataSourceName "MyDS" "Data source name should match"
+          }
+
+          test "sets description" {
+              let spec =
+                  bedrockDataSource "MyDS" {
+                      knowledgeBaseId "KB123"
+                      dataSourceConfiguration dummyDSConfig
+                      description "S3 data source"
+                  }
+
+              Expect.equal spec.Props.Description "S3 data source" "Description should be set"
+          }
+
+          test "sets dataDeletionPolicy" {
+              let spec =
+                  bedrockDataSource "MyDS" {
+                      knowledgeBaseId "KB123"
+                      dataSourceConfiguration dummyDSConfig
+                      dataDeletionPolicy "RETAIN"
+                  }
+
+              Expect.equal spec.Props.DataDeletionPolicy "RETAIN" "DataDeletionPolicy should be set"
+          }
+
+          test "mutable DataSource starts as None" {
+              let spec =
+                  bedrockDataSource "MyDS" {
+                      knowledgeBaseId "KB123"
+                      dataSourceConfiguration dummyDSConfig
+                  }
+
+              Expect.isNone spec.DataSource "DataSource should start as None"
+          } ]
+    |> testSequenced
+
+[<Tests>]
+let bedrockGuardrailTests =
+    testList
+        "Bedrock Guardrail DSL"
+        [ test "fails when blockedInputMessaging is missing" {
+              let thrower () =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedOutputsMessaging "Output blocked."
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when blockedInputMessaging is missing"
+          }
+
+          test "fails when blockedOutputsMessaging is missing" {
+              let thrower () =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                  }
+                  |> ignore
+
+              Expect.throws thrower "Should throw when blockedOutputsMessaging is missing"
+          }
+
+          test "sets guardrail name" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                  }
+
+              Expect.equal spec.GuardrailName "MyGuardrail" "Guardrail name should match"
+          }
+
+          test "defaults constructId to guardrail name" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                  }
+
+              Expect.equal spec.ConstructId "MyGuardrail" "ConstructId should default to guardrail name"
+          }
+
+          test "sets blocked messaging" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                  }
+
+              Expect.equal spec.Props.BlockedInputMessaging "Input blocked." "BlockedInputMessaging should be set"
+              Expect.equal spec.Props.BlockedOutputsMessaging "Output blocked." "BlockedOutputsMessaging should be set"
+          }
+
+          test "sets description" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                      description "Safety guardrail"
+                  }
+
+              Expect.equal spec.Props.Description "Safety guardrail" "Description should be set"
+          }
+
+          test "sets kmsKeyArn" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                      kmsKeyArn "arn:aws:kms:us-east-1:123456789012:key/my-key"
+                  }
+
+              Expect.equal
+                  spec.Props.KmsKeyArn
+                  "arn:aws:kms:us-east-1:123456789012:key/my-key"
+                  "KmsKeyArn should be set"
+          }
+
+          test "sets tags" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                      tags [ "Environment", "Production"; "Team", "AI" ]
+                  }
+
+              Expect.isNotNull spec.Props.Tags "Tags should be set"
+              Expect.equal (spec.Props.Tags |> Array.length) 2 "Should have 2 tags"
+          }
+
+          test "tags are empty by default" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                  }
+
+              Expect.isNull spec.Props.Tags "Tags should be null when no tags set"
+          }
+
+          test "mutable Guardrail starts as None" {
+              let spec =
+                  bedrockGuardrail "MyGuardrail" {
+                      blockedInputMessaging "Input blocked."
+                      blockedOutputsMessaging "Output blocked."
+                  }
+
+              Expect.isNone spec.Guardrail "Guardrail should start as None"
+          } ]
+    |> testSequenced

--- a/tests/FsCdk.Tests.fsproj
+++ b/tests/FsCdk.Tests.fsproj
@@ -57,6 +57,7 @@
         <Compile Include="ApiGatewayTests.fs" />
         <Compile Include="ECSTaskDefinitionTests.fs" />
         <Compile Include="SecurityDefaultsTests.fs" />
+        <Compile Include="BedrockTests.fs" />
         <Compile Include="SnapshotTests/S3SnapshotTests.fs" />
         <Compile Include="SnapshotTests/LambdaSnapshotTests.fs" />
         <Compile Include="Main.fs" />


### PR DESCRIPTION
## Summary

- Adds `src/Bedrock.fs` with 4 computation expression builders: `bedrockAgent`, `bedrockKnowledgeBase`, `bedrockDataSource`, `bedrockGuardrail`
- Integrates into `Stack.fs` with Operation DU cases, `processOperation`, `Yield`, and `Bind` methods for `let!` support
- Adds 35 Expecto tests covering required field validation, property assignment, tags, and mutable resource references

## Details

All builders follow the established Config/Spec/Builder pattern:
- **BedrockAgentBuilder** — wraps `CfnAgent` with foundation model, instruction, auto-prepare defaults
- **BedrockKnowledgeBaseBuilder** — wraps `CfnKnowledgeBase` with typed `IKnowledgeBaseConfigurationProperty` and `IStorageConfigurationProperty` parameters
- **BedrockDataSourceBuilder** — wraps `CfnDataSource` with typed `IDataSourceConfigurationProperty`, encryption, and vector ingestion config
- **BedrockGuardrailBuilder** — wraps `CfnGuardrail` with typed policy config interfaces (content, grounding, PII, topic, word) and `ICfnTag` conversion

Conventions followed:
- Typed CDK interface parameters (not `obj`) for type-safe custom operations
- Guarded tag `Combine` pattern (matching AppRunner/XRay)
- Inline `Yield`/`Zero` defaults, `state2.XxxName` in `Combine`
- `CfnTag` conversion from `(string * string) list` in `Run`
- Documentation script (`docs/bedrock.fsx`) and `docs/index.fsx` updated

## Build & Tests

- **Build**: 0 warnings, 0 errors
- **Tests**: 393 passed, 3 skipped (pre-existing RDS/XRay), 0 failures